### PR TITLE
Potential fix for code scanning alert no. 1: Expression injection in Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -37,9 +37,12 @@ jobs:
       working-directory: ./overtype
     - run: svn add * --force
       working-directory: ./overtype
-    - run: svn commit -m "${{ github.event.head_commit.message }}"
-        --username ${{ secrets.SVN_USERNAME }} 
-        --password ${{ secrets.SVN_PW }}     
+    - env:
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+      run: |
+        svn commit -m "$COMMIT_MESSAGE" \
+          --username ${{ secrets.SVN_USERNAME }} \
+          --password ${{ secrets.SVN_PW }}
       working-directory: ./overtype
     - name: update remote repo
       uses: garygrossgarten/github-action-ssh@release


### PR DESCRIPTION
Potential fix for [https://github.com/dethtron5000/overtype.com/security/code-scanning/1](https://github.com/dethtron5000/overtype.com/security/code-scanning/1)

To fix the issue, we will:
1. Assign the value of `github.event.head_commit.message` to an intermediate environment variable.
2. Use shell syntax (`"$VAR"`) to reference the environment variable in the `svn commit` command, ensuring that the input is treated as a literal string and not executed as a shell command.

This approach prevents command injection by ensuring that the commit message is safely passed as an argument to the `svn commit` command.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
